### PR TITLE
NeoEsp32I2sXMethod::IsWriteDone() misses `const` attribute

### DIFF
--- a/src/internal/methods/NeoEsp32I2sXMethod.h
+++ b/src/internal/methods/NeoEsp32I2sXMethod.h
@@ -469,7 +469,7 @@ public:
         }
     }
 
-    bool IsWriteDone()
+    bool IsWriteDone() const
     {
         return i2sWriteDone(T_BUS::I2sBusNumber);
     }


### PR DESCRIPTION
adding the missing `const` attribute to NeoEsp32I2sXMethod::IsWriteDone(). See https://github.com/Makuna/NeoPixelBus/issues/695